### PR TITLE
[nightshift] readme-improvements: add live URL header, browser support, AI dev section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # about
 
+<p align="center">
+  <a href="https://about.micr.dev"><strong>about.micr.dev</strong></a> · desktop-only personal archive
+</p>
+
 Personal portfolio/about page for [micr.dev](https://about.micr.dev). Part portfolio, part personal archive — a static site listing interests, tastes, and references in a two-column layout.
 
 ## Tech Stack
@@ -8,6 +12,10 @@ Personal portfolio/about page for [micr.dev](https://about.micr.dev). Part portf
 - **Custom font** — DecimaMono (self-hosted)
 - **Data-driven** — all content lives in `data.json`, rendered client-side
 - **Hosted on** [Netlify](https://netlify.com)
+
+## Browser Support
+
+Desktop browsers only. The site uses a fixed two-column layout at ≥1024px width. Mobile visitors see a blocker overlay with a message to visit on desktop.
 
 ## Project Structure
 
@@ -20,6 +28,8 @@ Personal portfolio/about page for [micr.dev](https://about.micr.dev). Part portf
 ├── fonts/
 │   └── DecimaMono.ttf  # Primary monospace font (preloaded)
 ├── images/             # Game covers, album art, designer logos, hero image
+├── .claude/
+│   └── skills/         # Claude Code skill constraints for UI work
 ├── favicon.png
 ├── robots.txt
 ├── sitemap.xml
@@ -28,7 +38,7 @@ Personal portfolio/about page for [micr.dev](https://about.micr.dev). Part portf
 
 ## How It Works
 
-1. `index.html` loads with skeleton placeholder UI.
+1. `index.html` loads with skeleton placeholder UI (shimmer animation while content loads).
 2. `script.js` waits for fonts and the hero image, then fetches `data.json`.
 3. Content is rendered dynamically based on each section's `type`:
    - **`intro`** — bio text with name header
@@ -62,7 +72,7 @@ Open `http://localhost:8000` in your browser.
 
 ## Customization
 
-All content is in **`data.json`**. Edit it directly to add, remove, or reorder sections.
+All content is in **`data.json`**. Edit it directly to add, remove, or reorder sections. The file is a JSON object where each top-level key is a section. The `displayName` field controls the section heading (defaults to the key name).
 
 ### Section types
 
@@ -100,6 +110,10 @@ Configured via `netlify.toml`:
 ```
 
 Push to the repository's main branch — Netlify auto-deploys from the root directory with no build command.
+
+## AI-Assisted Development
+
+This project includes a [Claude Code skill](/.claude/skills/ui-skills/) (`ui-skills`) that enforces opinionated UI constraints when working with AI coding agents. Invoke it with `/ui-skills` in Claude Code to apply layout, animation, typography, and accessibility rules to any changes.
 
 ## License
 


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** readme-improvements
**Category:** pr

## Changes

- **Live URL header**: Added centered link to about.micr.dev at the top of the README
- **Browser Support section**: Documented desktop-only constraint with minimum viewport width
- **Project Structure**: Added `.claude/skills/` entry to the directory tree
- **How It Works**: Clarified skeleton loader behavior (shimmer animation)
- **Customization**: Added note about JSON structure and `displayName` behavior
- **AI-Assisted Development section**: Documented the Claude Code `ui-skills` skill

## Notes

The original README was already comprehensive — these are targeted additions that fill documentation gaps without restructuring.

Merge if useful, close if not.